### PR TITLE
Fix code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/utils/discogs.js
+++ b/utils/discogs.js
@@ -2,6 +2,10 @@ const axios = require('axios');
 const { createDatabase, createAlbumsTable, createNotesTable, createListeningsTable } = require('../db/database');
 
 async function importCollectionFromDiscogs(userId, token, overwrite) {
+  const userIdPattern = /^[a-zA-Z0-9_-]+$/;
+  if (!userIdPattern.test(userId)) {
+    throw new Error('Invalid userId format');
+  }
   const url = `https://api.discogs.com/users/${userId}/collection/folders/0/releases?token=${token}&page=1&per_page=500`;
   try {
     console.log(`Fetching collection from Discogs for user: ${userId}`);


### PR DESCRIPTION
Fixes [https://github.com/macomeau/Vinyl-Journey/security/code-scanning/2](https://github.com/macomeau/Vinyl-Journey/security/code-scanning/2)

To fix the SSRF vulnerability, we should validate the `userId` parameter to ensure it conforms to expected values. Since `userId` should be a valid Discogs username, we can use a regular expression to validate it. This will prevent attackers from injecting malicious input into the URL.

1. Validate the `userId` parameter using a regular expression to ensure it only contains valid characters (e.g., alphanumeric characters, underscores, and hyphens).
2. If the `userId` is invalid, return an error response instead of proceeding with the request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
